### PR TITLE
fix: update collection names for the alerts received by modal window

### DIFF
--- a/src/Pages/Alert.jsx
+++ b/src/Pages/Alert.jsx
@@ -48,7 +48,7 @@ function AlertModal() {
   const locale = (qs.parse(window.location.search) || {}).locale || "en";
 
   useEffect(() => {
-    socket.on("alert message", (msg) => {
+    socket.on("alerts", (msg) => {
       if (!msg.isPrivate) {
         const type = (msg.alertType?.type || "default").toLowerCase();
         toast.dismiss();


### PR DESCRIPTION
Updates to the Web Sockets server have changed the name of the topic used to send the alert messages