### PR TITLE
fix: checked if /app/build/tenant folder exists

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,9 @@ elif [[ -z "$TENANT" ]]; then
     echo "Variable TENANT is set to the empty string, default logos will be used"
 else
     echo "Tenant is: $TENANT"
-    cp -v /app/build/$TENANT/* /app/build/
+    if [ -d "/app/build/$TENANT" ]; then
+        cp -v /app/build/$TENANT/* /app/build/
+    fi
 fi
 
 if [[ ! -v TITLE ]]; then


### PR DESCRIPTION
In the case of an "external" tenant, the folder may not exist in this repo. 
Added check on "directory" exists before applying the `cp` command